### PR TITLE
Setp 9 將網站中的中文部分共用化/ setp 10: 設定 Rails 的時區

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ before_script:
   - psql -c 'create database Practice_workshop_test;' -U postgres
 install:
   - bundle install
+  - nvm install node
+  - npm i -g yarn
+  - yarn
 cache:
   bundler: true
   directories:

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# Use I18n
+gem 'rails-i18n', '~> 6.0.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.2.1)
       actionpack (= 6.0.2.1)
       activesupport (= 6.0.2.1)
@@ -271,6 +274,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.3)
   rails (~> 6.0.2, >= 6.0.2.1)
+  rails-i18n (~> 6.0.0)
   rspec-rails (~> 3.9)
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with model: task do |f| %>
-  <%= f.label :title, '標題' %>
+  <%= f.label :title, t('view.title') %>
   <%= f.text_field :title %>
   <br>
-  <%= f.label :content, '內容' %>
+  <%= f.label :content, t('view.content') %>
   <%= f.text_area :content %>
   <br>
-  <%= f.submit '送出' %>
+  <%= f.submit t('button.create') %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,12 +1,12 @@
 <h1>首頁</h1>
-<%= link_to '新增任務', new_task_path %>
+<%= link_to t('view.new'), new_task_path %>
 
 <ul>
   <% @tasks.each do |task| %>
     <li>
       <%= task.title %>
-      <%= link_to '編輯', edit_task_path(task) %>
-      <%= link_to '刪除', task_path(task), method:'delete', data: { confirm: '確認刪除？'} %>
+      <%= link_to t('view.edit'), edit_task_path(task) %>
+      <%= link_to t('view.destroy'), task_path(task), method:'delete', data: { confirm: '確認刪除？'} %>
     </li>
   <% end %>
 </ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module PracticeWorkshop
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = "zh-TW"
+    config.time_zone = "Taipei"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,0 +1,9 @@
+zh-TW:
+  view:
+    title: 標題
+    edit: 編輯
+    destroy: 刪除
+    new: 新增任務
+    content: 內容
+  button:
+    create: 送出


### PR DESCRIPTION
步驟9: 將網站中的中文部分共用化
- [x] 利用 Rails 的 i18n 功能，將 View / Controller / Model 中的語言部份共用化
※ i18n 化的好處是，之後的步驟中，各種訊息的處理會輕鬆很多

步驟10: 設定 Rails 的時區
- [x] 將 Rails 的時區設為台灣（台北）